### PR TITLE
Reflecting the minimum php version required on Cypht 1.4

### DIFF
--- a/install.html
+++ b/install.html
@@ -59,7 +59,7 @@
         <h2>Installation</h2>
         <hr>
         <h2>Requirements</h2>
-        <p>      Cypht requires at least PHP 5.4, <a href="https://getcomposer.org/">Composer 2</a>, and at minimum the <a href="http://php.net/manual/en/book.openssl.php">OpenSSL</a>, <a href="http://php.net/manual/en/book.mbstring.php">mbstring</a> and <a href="http://php.net/manual/en/book.curl.php">cURL</a> extensions. Cypht can also leverage several other extensions as defined in <a href="https://github.com/cypht-org/cypht/blob/master/composer.json#L37-L44">composer.json</a>. Testing is done on <a href="https://www.debian.org/">Debian</a> and <a href="http://www.ubuntu.com/">Ubuntu</a> platforms with <a href="http://nginx.com/">Nginx</a> and <a href="http://httpd.apache.org/">Apache</a>.
+        <p>      Cypht requires at least PHP 5.6, <a href="https://getcomposer.org/">Composer 2</a>, and at minimum the <a href="http://php.net/manual/en/book.openssl.php">OpenSSL</a>, <a href="http://php.net/manual/en/book.mbstring.php">mbstring</a> and <a href="http://php.net/manual/en/book.curl.php">cURL</a> extensions. Cypht can also leverage several other extensions as defined in <a href="https://github.com/cypht-org/cypht/blob/master/composer.json#L37-L44">composer.json</a>. Testing is done on <a href="https://www.debian.org/">Debian</a> and <a href="http://www.ubuntu.com/">Ubuntu</a> platforms with <a href="http://nginx.com/">Nginx</a> and <a href="http://httpd.apache.org/">Apache</a>.
         </p>
         <p>Before proceeding please make sure your system meets minimal requirements</p>
         <h2>Steps</h2>
@@ -67,7 +67,7 @@
         <p><pre>
 #!/bin/bash
 
-# You need to check php version which should be >=5.4
+# You need to check php version which should be >=5.6
 php --version
 
 # Next you need to check composer version which should be >=2.0.0


### PR DESCRIPTION
Reflecting the minimum php version required in the Cypht 1.4 installation instructions
(**php 5.6**)