### PR TITLE
[UX]Buttons (with class btn-success): adding 0.3125rem margin to the t…

### DIFF
--- a/site.css
+++ b/site.css
@@ -494,7 +494,8 @@ a.btn.disabled {
 .btn-success {
 	color: #fff;
 	background-color: #28a745;
-	border-color: #28a745
+	border-color: #28a745;
+	margin: 0.3125rem 0.3125rem 0.3125rem 0.3125rem; /* top, right, bottom, left */
 }
 
 .btn-success:hover {


### PR DESCRIPTION
[UX]Buttons (with class btn-success): adding 0.3125rem margin to the top, right, bottom, and left sides.
They were looking like(on mobile):
<img width="179" alt="contribute html" src="https://github.com/cypht-org/cypht-website/assets/81784141/16ae4565-e478-4e20-b2ae-3edccd1041d8">

<img width="182" alt="install html" src="https://github.com/cypht-org/cypht-website/assets/81784141/d35e1a2f-d0d1-40d5-a753-ce926e2e70cd">

