### PR TITLE
[DOC] Update installation scripts for managing users and setup database

### DIFF
--- a/install-2x.html
+++ b/install-2x.html
@@ -233,14 +233,17 @@ sudo php ./scripts/config_gen.php</pre>
     <p>Setting up users depends on what type of authentication you configure in the config/app.php file. If you are
       using the local database configuration for users, there are scripts in the scripts/ directory to help manage them:
     <pre>
-        # create an account
-        php ./scripts/create_account.php username password
+# Generate necessary tables to manage users,sessions, or settings depending on the configuration in the .env file
+php ./scripts/setup_database.php
+      
+# create an account
+php ./scripts/create_account.php username password
 
-        # delete an account
-        php ./scripts/delete_account.php username
+# delete an account
+php ./scripts/delete_account.php username
 
-        # change an account password
-        php ./scripts/update_password.php username password
+# change an account password
+php ./scripts/update_password.php username password
     </pre>
     </p>
     <h4>7. Debug mode</h4>

--- a/install.html
+++ b/install.html
@@ -226,6 +226,9 @@ sudo php ./scripts/config_gen.php</pre>
         <p>Setting up users depends on what type of authentication you configure in the .env file. If you are using the
             local database configuration for users, there are scripts in the scripts/ directory to help manage them:
         <pre>
+# Generate necessary tables to manage users,sessions, or settings depending on the configuration in the .env file
+php ./scripts/setup_database.php
+
 # create an account
 php ./scripts/create_account.php username password
 
@@ -233,7 +236,8 @@ php ./scripts/create_account.php username password
 php ./scripts/delete_account.php username
 
 # change an account password
-php ./scripts/update_password.php username password</pre>
+php ./scripts/update_password.php username password
+        </pre>
         </p>
         <h4>7. Debug mode</h4>
         <p>Cypht has a debug or developer mode that can be used to troubleshoot problems or enable faster development of


### PR DESCRIPTION
This PR updates installation scripts for setting up database tables to manage users. Some users were trying to run 
`php ./scripts/create_account.php` and encountering errors because the tables were not created. In some cases, users may not know how to create these tables

Once [https://github.com/cypht-org/cypht/pull/1090](https://github.com/cypht-org/cypht/pull/1090) is merged