### PR TITLE
[FIX] config-generator small fixes & updates

### DIFF
--- a/data/configOptions.json
+++ b/data/configOptions.json
@@ -612,6 +612,22 @@
             "setValues": null
         },
         {
+            "key": "DEFAULT_SETTING_SNOOZED_SINCE",
+            "valueDefault": "-1 week",
+            "comment": "Per source time limit for snoozed page\nDefaults to 1 week",
+            "commentHtml": "Per&nbsp;source&nbsp;time&nbsp;limit&nbsp;for&nbsp;snoozed&nbsp;page\nDefaults&nbsp;to&nbsp;1&nbsp;week",
+            "inputType": "text",
+            "setValues": null
+        },
+        {
+            "key": "DEFAULT_SETTING_SNOOZED_PER_SOURCE",
+            "valueDefault": "20",
+            "comment": "Per source number limit for snoozed page\nDefaults 20",
+            "commentHtml": "Per&nbsp;source&nbsp;number&nbsp;limit&nbsp;for&nbsp;snoozed&nbsp;page\nDefaults&nbsp;20",
+            "inputType": "text",
+            "setValues": null
+        },
+        {
             "key": "DEFAULT_SETTING_TAGS_SINCE",
             "valueDefault": "-1 week",
             "comment": "Per source time limit for tags page\nDefaults to 1 week",

--- a/data/fetch.php
+++ b/data/fetch.php
@@ -103,6 +103,7 @@ for ($i = 0; $i < count($FILES); $i++) {
                 case "API_LOGIN_KEY":
                 case "MEMCACHED_USER":
                 case "SESSION_CLASS":
+                case "GMAIL_CLIENT_ID":
                     $inputType = "text";
                     break;
                 

--- a/layouts/partials/config-generator.html.twig
+++ b/layouts/partials/config-generator.html.twig
@@ -76,7 +76,7 @@
     <textarea class="container" id="result"></textarea>
     <nav>
         <ul>
-            <a href="https://github.com/Denperidge/cypht-config-generator">
+            <a href="https://github.com/cypht-org/cypht-website#cypht-config-generator-generator">
                 <li>Source code</li>
             </a>
         </ul>


### PR DESCRIPTION
Not a big patch, but wanted to let another contributor take a look before merging!

This will actually close #102, or rather, prevent it from happening again

- New runs of fetch.php will no longer set GMAIL_CLIENT_ID (Thanks to @pho3nixf1re for discovering the bug and fixing the deployment until now!)
- Ran fetch.php, which added two new config options
- Updated the link to the source code to the current version instead of the old config-generator