### PR TITLE
[FIX] Semantic HTML & validation error squashing

### DIFF
--- a/layouts/page.html.twig
+++ b/layouts/page.html.twig
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="no-js">
+<html lang="en" class="no-js">
 
 <head>
     <meta charset="utf-8">
@@ -13,8 +13,11 @@
 </head>
 
 <body>
+    {% if not page.h1 is defined or page.h1 != false %}
+    <h1 class="sr-only">{{page.h1 |default(page.title)}}</h1>
+    {% endif %}
     <header>
-        <nav class="navbar navbar-expand-lg navbar-dark  fixed-top">
+        <nav aria-label="Site navigation" class="navbar navbar-expand-lg navbar-dark  fixed-top">
             <div class="container">
                 <a class="navbar-brand" href="/">
                     <img src="/img/logo.svg" width="120" height="60" alt="">
@@ -63,43 +66,46 @@
     {% endif %}
 
     
-    <section class="footer-section" id="contact">
-        <div class="container text-center">
-            <h2>Have a suggestion or a question?</h2>
-            <h3>Or maybe you want to throw huge wads of cash at us? </h3>
-            <p>We love feedback so let us know what you think!</p>
-        </div>
-    </section>
-    <section class=" social-section text-center">
-        <div class="container">
-            <div class="row">
-                <div class="col-3 col-md-3 col-sm-12">
-                    <p>
-                        <span>Page on Github</span><br>
-                        <a href="https://github.com/cypht-org/cypht-website/blob/master/pages/{{page.path}}.md">Edit here</a>
-                    </p>
-                </div>
-                <div class="col-3 col-md-3 col-sm-12">
-                    <p>
-                        <span>Fill out an issue at Github</span><br>
-                        <a href="https://github.com/cypht-org/cypht/issues">Submit an issue</a>
-                    </p>
-                </div>
-                <div class="col-3 col-md-3 col-sm-12">
-                    <p>
-                        <span>Chat with us at Gitter</span><br>
-                        <a href="https://gitter.im/cypht-org/community">Cypht at Gitter</a>
-                    </p>
-                </div>
-                <div class="col-3 col-md-3 col-sm-12">
-                    <p>
-                        <span>Want to contribute?</span><br>
-                        <a href="/contribute">Cypht website contribution</a>
-                    </p>
+    <footer>
+        <section class="footer-section" id="contact">
+            <div class="container text-center">
+                <h2>Have a suggestion or a question?</h2>
+                <h3>Or maybe you want to throw huge wads of cash at us? </h3>
+                <p>We love feedback so let us know what you think!</p>
+            </div>
+        </section>
+        <nav aria-label="Developer links" class=" social-section text-center">
+            <h2 class="sr-only">Developer links</h2>
+            <div class="container">
+                <div class="row">
+                    <div class="col-3 col-md-3 col-sm-12">
+                        <p>
+                            <span>Page on Github</span><br>
+                            <a href="https://github.com/cypht-org/cypht-website/blob/master/pages/{{page.path}}.md">Edit here</a>
+                        </p>
+                    </div>
+                    <div class="col-3 col-md-3 col-sm-12">
+                        <p>
+                            <span>Fill out an issue at Github</span><br>
+                            <a href="https://github.com/cypht-org/cypht/issues">Submit an issue</a>
+                        </p>
+                    </div>
+                    <div class="col-3 col-md-3 col-sm-12">
+                        <p>
+                            <span>Chat with us at Gitter</span><br>
+                            <a href="https://gitter.im/cypht-org/community">Cypht at Gitter</a>
+                        </p>
+                    </div>
+                    <div class="col-3 col-md-3 col-sm-12">
+                        <p>
+                            <span>Want to contribute?</span><br>
+                            <a href="/contribute">Cypht website contribution</a>
+                        </p>
+                    </div>
                 </div>
             </div>
-        </div>
-    </section>
+        </nav>
+    </footer>
     <script src="/jquery.slim.min.js"></script>
     <script src="/bootstrap.bundle.min.js"></script>
     {% if page.loadScriptAfter is defined %}

--- a/layouts/page.html.twig
+++ b/layouts/page.html.twig
@@ -57,12 +57,12 @@
     {% if page.nocontainer is defined %}
         {{page.content}}
     {% else %}
-        <section class="content-section container">
+        <main class="content-section container">
             {{page.content}}
             {% if page.path == 'config-generator' %}
                 {{- include('partials/config-generator.html.twig') ~}}
             {% endif %}
-        </section>
+        </main>
     {% endif %}
 
     

--- a/layouts/partials/config-generator.html.twig
+++ b/layouts/partials/config-generator.html.twig
@@ -1,25 +1,4 @@
-<style>
-    main {
-        width: 80%;
-        margin: auto;
-    }
-
-    fieldset#CYPHT_MODULES {
-        word-break: break-all;
-    }
-
-    #generate,
-    #reset-all {
-        margin: auto;
-        display: block;
-        margin-bottom: 20px;
-    }
-
-    #result {
-        height: 600px;
-    }
-</style>
-<main>
+<form id="config-generator">
     <h1>Cypht Config Generator</h1>
     <blockquote>
         Click any of the options below to configure Cypht!<br>
@@ -27,8 +6,8 @@
     </blockquote>
     {% for file in site.data.configFiles %}
     <details>
-        <summary class="h4" role="button">
-            {{file | replace({".php": ""})}}
+        <summary class="h4">
+            <h2 class="h4">{{file | replace({".php": ""})}}</h2>
         </summary>
         {% for option in site.data.configOptions[file] %}
         {% set select = option.inputType == "select" %}
@@ -43,7 +22,7 @@
             {% if not select %}
             <input id="{{inputId}}" type="{{option.inputType}}" name="{{option.key}}"
                 data-default="{{option.valueDefault}}" {% if option.valueDefault %} {% if option.inputType=="checkbox"
-                and option.valueDefault=="true" %} checked="true" {% else %} value="{{option.valueDefault}}" {% endif %}
+                and option.valueDefault=="true" %} checked {% else %} value="{{option.valueDefault}}" {% endif %}
                 {% endif %} />
             {% else %}
             <select class="btn btn-light text-left" id="{{inputId}}" name="{{option.key}}" data-default="{{option.valueDefault}}">
@@ -53,8 +32,6 @@
             </select>
             {% endif %}
             <button class="reset btn btn-light">Reset</button>
-
-
         </fieldset>
         {% endfor %}
     </details>
@@ -74,11 +51,12 @@
         </a> for more info
     </p>
     <textarea class="container" id="result"></textarea>
-    <nav>
-        <ul>
-            <a href="https://github.com/Denperidge/cypht-config-generator">
-                <li>Source code</li>
-            </a>
-        </ul>
-    </nav>
-</main>
+    
+    <hr>
+
+    <p>The 
+        <a href="https://github.com/Denperidge/cypht-config-generator">
+            config-generator source code can be found on GitHub
+        </a>
+    </p>
+</form>

--- a/pages/config-generator.md
+++ b/pages/config-generator.md
@@ -2,4 +2,5 @@
 title: Config generator
 weight: 21
 loadScriptAfter: /config-generator.js
+h1: false
 ---

--- a/pages/contribute.md
+++ b/pages/contribute.md
@@ -2,6 +2,7 @@
 title: Contribute
 weight: 40
 nocontainer: true
+h1: Contributing to Cypht
 ---
 <section class="contibute-section container">
  <div class="container">
@@ -49,14 +50,14 @@ nocontainer: true
     <p>We love feedback so let us know what you think! <br> Leave a comment, submit your problem or contribute to
         the project <br> by joining the community first.
     </p>
-    <a href="https://github.com/cypht-org/cypht/">
-        <button type="button" class="btn btn-success">GitHub</button>
+    <a class="btn btn-success" href="https://github.com/cypht-org/cypht/">
+        GitHub
     </a>
-    <a href="https://gitter.im/cypht-org/community">
-        <button type="button" class="btn btn-success">Gitter</button>
+    <a class="btn btn-success" href="https://gitter.im/cypht-org/community">
+        Gitter
     </a>
-    <a href="https://www.openhub.net/p/cypht/users">
-        <button type="button" class="btn btn-success">OpenHub</button>
+    <a class="btn btn-success" href="https://www.openhub.net/p/cypht/users">
+        OpenHub
     </a>
 </div>
 </section>

--- a/pages/contribute.md
+++ b/pages/contribute.md
@@ -4,7 +4,7 @@ weight: 40
 nocontainer: true
 h1: Contributing to Cypht
 ---
-<section class="contibute-section container">
+<main class="contibute-section container">
  <div class="container">
     <h2 id="contributing">Want to contribute?</h2>
     <p>First of all, thank you for interest to cypht! The goal of this page is to provide everything you need to know in order to contribute to cypht-website and its different integrations.</p>
@@ -60,4 +60,4 @@ h1: Contributing to Cypht
         OpenHub
     </a>
 </div>
-</section>
+</main>

--- a/pages/developers-documentation.md
+++ b/pages/developers-documentation.md
@@ -3,7 +3,7 @@ title: Devs-doc
 weight: 35
 nocontainer: true
 ---
-<section class="dev-docs-section contibute-section container">
+<main class="dev-docs-section contibute-section container">
     <div class="container">
         <h2>Folder structure</h2>
         <h3 class="bold-title"><b>.github</b></h3>
@@ -792,4 +792,4 @@ nocontainer: true
     <a href="https://p5r.uk/blog/2011/sieve-tutorial.html">https://p5r.uk/blog/2011/sieve-tutorial.html</a><br>
     <a href="https://www.fastmail.com/help/technical/sieve.html">https://www.fastmail.com/help/technical/sieve.html</a><br>
     <a href="https://docs.gandi.net/en/gandimail/sieve/sieve_tutorial.html">https://docs.gandi.net/en/gandimail/sieve/sieve_tutorial.html</a>
-</section>
+</main>

--- a/pages/developers-documentation.md
+++ b/pages/developers-documentation.md
@@ -3,43 +3,7 @@ title: Devs-doc
 weight: 35
 nocontainer: true
 ---
-<style>
-    .highlight-text {
-	font-size: 18px;
-	color: #0e0d0d;
-}
-
-.highlight-secondary {
-	color: #635108;
-}
-
-.code-block {
-	display: block;
-	background-color: #1e1e1e;
-	color: #f8f8f2;
-	padding: 15px;
-	border-radius: 5px;
-	font-size: 16px;
-	line-height: 1;
-	overflow-x: auto;
-	white-space: pre-wrap;
-	margin-bottom: 20px;
-}
-
-.function-keyword {
-	color: #66d9ef;
-}
-
-.default-text {
-	color: #f8f8f2;
-}
-
-.bold-title {
-    font-weight: bold;
-}
-</style>
-
-<section class="contibute-section container">
+<section class="dev-docs-section contibute-section container">
     <div class="container">
         <h2>Folder structure</h2>
         <h3 class="bold-title"><b>.github</b></h3>
@@ -90,7 +54,7 @@ nocontainer: true
         <h3 class="bold-title"><b>.env</b></h3>
         <p>The .env file is for high-level configuration. For any variables you're unsure about, check the
             configuration folder for detailed explanations.</p>
-        <h1>How to</h1>
+        <h2>How to</h2>
         <h3 class="bold-title"><b>See the new link in the left menu</b></h3>
         <p>Sometimes you can add a link to the left menu without seeing it. Cypht caches all menus. You need to
             click on the reload link below the navigation menu.</p>

--- a/pages/documentation.md
+++ b/pages/documentation.md
@@ -2,6 +2,7 @@
 title: "Documentation"
 weight: 30
 nocontainer: true
+h1: false
 ---
 <div style="margin-top: 100px;"></div>
 
@@ -46,7 +47,7 @@ nocontainer: true
 <section class="content-section-doc container">
     <div class="line ">
         <div class="element2 item">
-            <h1>Adding IMAP/JMAP/SMTP Servers and ATOM/RSS Feed</h1>
+            <h2>Adding IMAP/JMAP/SMTP Servers and ATOM/RSS Feed</h2>
             <p class="text-center">Enhanced customization capabilities allow user to setup, configure, and manage IMAP and SMTP or SMTP and JMAP servers and setup the ATOM/RSS Feed. Adding servers in Cypht is a straightforward process that involves two main steps. These steps are illustrated in the following image for your reference.</p>
         </div>
         <div class="element1 item">
@@ -58,7 +59,7 @@ nocontainer: true
 <section class="content-section-doc container">
     <div class="line ">
         <div class="element2 item">
-            <h1>Adding EWS Servers</h1>
+            <h2>Adding EWS Servers</h2>
             <p class="text-center">Cypht supports seamless integration with Exchange servers through easy setup and configuration. This section allows users to add, configure, and manage Exchange servers (EWS). Adding an Exchange server involves filling out key details such as server address, username, and password, with options to customize settings like creating profiles, setting a default profile, and adding a signature. The right-hand preview shows the Exchange inbox interface, highlighting features such as folder navigation and email list display. This process is designed to simplify Exchange account management for users, as illustrated in the image below.</p>
         </div>
         <div class="element1 item">
@@ -70,7 +71,7 @@ nocontainer: true
 <section class="content-section-doc container">
     <div class="line">
         <div class="element2 item">
-            <h1>Combined Inbox</h1>
+            <h2>Combined Inbox</h2>
             <p>The advanced and most efficient service of the Cypht enables users to access multiple email accounts at the same time.
                 The users can view inboxes of different email providers and can send, receive, and manage email messages from the interactive webmail.
                 Also, the webmail allows provides the functionality to search, sort, and filter emails.</p>
@@ -84,7 +85,7 @@ nocontainer: true
 <section class="content-section-doc container">
     <div class="line">
         <div class="element2 item">
-            <h1>Combined View</h1>
+            <h2>Combined View</h2>
             <p>Cypht, your email client that allows you to access multiple email accounts simultaneously, features main folders such as Drafts, Everything, Flagged, Junk, Sent, Snoozed, Trash, and Unread. To ensure that email messages from your accounts appear in these folders, you need to add them by accessing the respective folder and clicking the "Add this folder to combined pages" icon located in the header of your folder view. This action integrates the folder into the combined view, making it easier to manage emails across all your accounts in one place. Refer to the provided image for visual guidance.</p>
         </div>
         <div class="element1 item">
@@ -99,7 +100,7 @@ nocontainer: true
             <img src="/img/Contact.PNG" alt="Contact" class="img-fluid">
         </div>
         <div class="element2 item">
-            <h1>Contact Book</h1>
+            <h2>Contact Book</h2>
             <p>One-click Contact Book  allows users to efficiently add people to your contacts.
                 Contacts can be added via clicking the Contacts button from the main menu,</p>
         </div>
@@ -120,7 +121,7 @@ nocontainer: true
 <section class="content-section-doc container">
     <div class="line">
         <div class="element2 item">
-            <h1>Calendar</h1>
+            <h2>Calendar</h2>
             <p>The calendar feature allows user to create different events by clicking the “+” icon on top-right corner.
                 The created reminders and events will be shown in the calendar making it easier for user to keep track of the special events.</p>
         </div>
@@ -136,7 +137,7 @@ nocontainer: true
             <img src="/img/Compose.PNG" alt="Compose" class="img-fluid">
         </div>
         <div class="element2 item">
-            <h1>Compose Email</h1>
+            <h2>Compose Email</h2>
             <p>The webmail offers simple and interactive interface to compose and send an email message from any of the added email accounts along with the functionalities to access draft emails by clicking the “document” icon on top-right corner, add signatures, attachments, etc.</p>
         </div>
     </div>
@@ -147,7 +148,7 @@ nocontainer: true
     <div class="line">
 
         <div class="element2 item">
-            <h1>User Profiles</h1>
+            <h2>User Profiles</h2>
             <p>From webmail settings options, the user can access the feature to add numerous profiles in the webmail allowing users to combine IMAP accounts with SMTP accounts and setup signatures and reply-to details.</p>
         </div>
         <div class="element1 item">
@@ -162,7 +163,7 @@ nocontainer: true
             <img src="/img/Developer.PNG" alt="developer" class="img-fluid">
         </div>
         <div class="element2 item">
-            <h1>Developer Options</h1>
+            <h2>Developer Options</h2>
             <p> Another interesting feature of the open-source platform is its provision of the developer documentation and links to the source code. Thereby enabling the developer community of the webmail to actively contribute to making the platform more efficient, advanced, and reliable.</p>
         </div>
     </div>
@@ -170,9 +171,8 @@ nocontainer: true
 
 <section class="content-section-doc container">
     <div class="line">
-
         <div class="element2 item">
-            <h1>Sieve filters</h1>
+            <h2>Sieve filters</h2>
             <p>Sieve filters can be set up to automatically move, copy, or delete messages based on specific criteria such as sender, subject, keywords, or recipient. To add a Sieve filter, navigate to the Sieve Filters menu located in the Settings tab sidebar, select the email account for which you want to create a filter, and click the "Add Filter" button. Refer to the following image for a visual guide.</p>
         </div>
         <div class="element1 item">
@@ -184,7 +184,7 @@ nocontainer: true
 <section class="content-section-doc container">
     <div class="line">
         <div class="element2 item">
-            <h1>Block List</h1>
+            <h2>Block List</h2>
             <p>
                 The Block List feature allows users to block specific email addresses or domains from sending emails to your inbox. To block a sender in Cypht Webmail, open the email, click the BLOCK SENDER button (lock icon), and choose whether to block This Sender or the Whole Domain. Then select an action: Default Action, Discard, Move to Blocked Folder, Reject with Default Message, or Reject with Specific Message, and confirm by clicking BLOCK. You can manage blocked senders later under Settings > Block List. Make sure Sieve filters are enabled in your Cypht settings for this feature to work. Refer to the following image for a visual guide.
             </p>
@@ -201,7 +201,7 @@ nocontainer: true
             <img src="/img/snooze.png" alt="snooze" class="img-fluid">
         </div>
         <div class="element2 item">
-            <h1>Snooze</h1>
+            <h2>Snooze</h2>
             <p>The snooze feature allows user  to snooze the email with choices like 1 day, 1 week, 1 month, pick a date. The snoozed emails should all be findable in a "snoozed" folder (or similar name), with a column for the snoozed-until date.
                 Here, you can un-snooze them (it becomes a normal email), or change the snooze date. At the end of the snooze period, the email should appear in a dedicated section above all other emails. Then, you deal with them, or snooze them again. Alternate names for this feature : Snooze,Defer,Postpone,Delay,Reminder.
             </p>
@@ -212,7 +212,7 @@ nocontainer: true
 <section class="content-section-doc container">
     <div class="line">
         <div class="element2 item">
-            <h1>Archive</h1>
+            <h2>Archive</h2>
             <p>To archive emails in Cypht, you'll need to create an archive folder. The 'Archive' button is always available, but you won't be able to use it until you've set up a destination folder. Once you've done that, clicking 'Archive' will move the email to the designated folder and display a confirmation message.
             </p>
         </div>

--- a/pages/documentation.md
+++ b/pages/documentation.md
@@ -6,6 +6,7 @@ h1: false
 ---
 <div style="margin-top: 100px;"></div>
 
+<main>
 <section class="content-section-doc container">
     <div class="line">
         <div  class="element1 item ">
@@ -221,3 +222,4 @@ h1: false
         </div>
     </div>
 </section>
+</main>

--- a/pages/email-filters.md
+++ b/pages/email-filters.md
@@ -10,28 +10,24 @@ exclude: true
     However, it is important to note that your email server must support Sieve for these filters to function properly.</p>
 <p>Here are just a few of the things you can do with Sieve:</p>
 <hr>
-<ul>
+<ul class="line-between">
     <li>
         Filter out spam and unwanted emails. Sieve filters can be used to filter out spam and unwanted emails based on
         their sender, subject, or content.
     </li>
-    <hr>
     <li>
         Organize your inbox automatically. Sieve filters can be used to automatically move or copy your emails into
         different folders based on their sender, subject, or content.
     </li>
-    <hr>
     <li>
         Forward important emails to specific people. Sieve filters can be used to automatically forward important emails
         to specific people, such as your manager or your assistant.
     </li>
-    <hr>
     <li>
         Sieve filters can be used to create custom notifications and alerts for important emails, such as those from
         your boss or clients. Unlike simply forwarding the email, these notifications and alerts can provide immediate
         and specific information, ensuring you stay updated without needing to sift through your inbox.
     </li>
-    <hr>
 </ul>
 <p>To get started with Sieve in Cypht, simply go to your config file (hm3.ini for Cypht 1.4.x or .env for Cypht 2.0.x)
     and enable the Sieve filter engine by enabling modules[ ]=sievefilters or by adding sievefilters on CYPHT_MODULES
@@ -112,8 +108,8 @@ if header :subject "Important" {
 }
 </pre>
 <h3>Related links:</h3>
-<a href="http://sieve.info/">http://sieve.info/</a><br>
-<a href="https://p5r.uk/blog/2011/sieve-tutorial.html">https://p5r.uk/blog/2011/sieve-tutorial.html</a><br>
-<a href="https://www.fastmail.com/help/technical/sieve.html">https://www.fastmail.com/help/technical/sieve.html</a><br>
-<a href="https://docs.gandi.net/en/gandimail/sieve/sieve_tutorial.html">https://docs.gandi.net/en/gandimail/sieve/sieve_tutorial.html</a>
-<br />
+
+- http://sieve.info/
+- https://p5r.uk/blog/2011/sieve-tutorial.html
+- https://www.fastmail.com/help/technical/sieve.html
+- https://docs.gandi.net/en/gandimail/sieve/sieve_tutorial.html

--- a/pages/features.md
+++ b/pages/features.md
@@ -4,30 +4,25 @@ weight: 10
 ---
 <h2>List of Features</h2>
 <hr>
-<ul>
+<ul class="line-between">
     <li>
         Combined inbox, unread, sent, and flagged message views for all your E-mail accounts (and
         RSS feeds), as well as standard E-mail client folder navigation
     </li>
-    <hr>
     <li>
         Flexible profiles to combine IMAP accounts with SMTP accounts and setup signatures and
         reply-to details
     </li>
-    <hr>
     <li>
         Search all your E-mail accounts and RSS feeds at once with a simple form., or do complex searches across
         your accounts with the advanced search module set
     </li>
-    <hr>
     <li>
         Move or copy emails from one account to another
     </li>
-    <hr>
     <li>
         Compose messages in plain text, HTML, or Markdown
     </li>
-    <hr>
     <li>
         Pages are comprised of only 3 HTTP requests totaling ~50KB (gzipped). Data to
         populate a page from different sources is collected with parallel AJAX
@@ -36,59 +31,49 @@ weight: 10
         data-urls so they are served inline (and they can all be disabled). With
         standard browser caching, pages tend to transfer 10 to 20 KB
     </li>
-    <hr>
     <li>
         Simple interface translation system that does not use gettext or .po files, just
         arrays of translated strings defined in PHP. Right to left languages are supported.
     </li>
-    <hr>
     <li>
         Module sets for IMAP, SMTP, LDAP or local contacts, WordPress, Github,
         and lots more! Check out the <a href="/modules">Modules</a> page for a
         complete list
     </li>
-    <hr>
     <li>
         Sessions and user data can be stored in any PDO compatible database or flat
         files on the server
     </li>
-    <hr>
     <li>
         Authentication is flexible and currently supports IMAP, LDAP, an included
         database schema, dynamic authentication using popular E-mail providers,
         auto-discovery based on the user's E-mail domain, or you can roll your own with
         the site module set
     </li>
-    <hr>
     <li>
         Sessions and Authentication can be customized without breaking any modules using
         the site module set
     </li>
-    <hr>
     <li>
         On the server, page request processing peaks at around 4-5MB of memory. The module system only includes PHP
         files required to process the
         current request, so time is not wasted parsing unused code paths
     </li>
-    <hr>
     <li>
         All the work of processing a request and providing a response is done with
         module sets. The application framework manages module assignment and provides a
         controlled execution environment, but modules are where the actual work is done
     </li>
-    <hr>
     <li>
         There is a build process that pre-calculates module assignments and combines
         and compresses page assets, making the production version of your site as fast
         as possible. There is also a developer mode in which individual components are
         included directly for easy debugging and module development
     </li>
-    <hr>
     <li>
         The HTML5 Page structure is semantic and simple, with attention paid to
         accessibility best-practices
     </li>
-    <hr>
     <li>
         Save the parameters of a search so that you can quickly access them later from
         the menu without having to enter them again. This is particularly useful for parameters of
@@ -97,47 +82,36 @@ weight: 10
     <li>
         Sieve filters can be created to automatically move, copy, or delete messages based on specific criteria such as sender, subject, keywords, or recipient. This allows for efficient organization and management of incoming emails, saving time and improving productivity. Sieve filters can be easily edited or deleted as needed. For more information on how to create and manage Sieve filters, see <a href="/email-filters">Email filters</a>.
     </li>
-    <hr>
     <li>
         JMAP (JSON Meta Application Protocol) support for faster, more efficient synchronization of emails across devices.
     </li>
-    <hr>
     <li>
         Snooze feature to temporarily hide emails and bring them back at a more convenient time.
     </li>
-    <hr>
     <li>
         Screen emails to help manage unwanted or irrelevant communications by filtering or prioritizing certain types of messages.
     </li>
-    <hr>
     <li>
         IMAP capabilities for sharing folders to allow collaboration by sharing email folders between accounts.
     </li>
-    <hr>
     <li>
         Delivery receipt to get confirmation when your emails are delivered to the recipient's inbox.
     </li>
-    <hr>
     <li>
         Support for setting and managing environment variables to customize server-side configurations.
     </li>
-    <hr>
     <li>
         IMAP folder subscriptions for managing which folders you want to subscribe to and view in your mail client.
     </li>
-    <hr>
     <li>
         Collected Recipients and Trusted Senders feature to track commonly contacted people and trusted email addresses for enhanced security and efficiency.
     </li>
-    <hr>
     <li>
         A simpler way to show the source of an email for better understanding of its origin and security analysis.
     </li>
-    <hr>
     <li>
         Tags/Labels support to organize and categorize emails easily for better management and quick access to relevant content.
     </li>
-    <hr>
     <li>
         Exchange Web Services (EWS) support is in development. For more details and updates, check out the progress <a href="https://github.com/cypht-org/cypht/pull/1278">here</a>.
     </li>

--- a/pages/how-to-join.md
+++ b/pages/how-to-join.md
@@ -2,6 +2,7 @@
 title: How to join
 nocontainer: true
 exclude: true
+h1: false
 ---
 <section class="contibute-section container">
     <div class="container">

--- a/pages/how-to-join.md
+++ b/pages/how-to-join.md
@@ -4,7 +4,7 @@ nocontainer: true
 exclude: true
 h1: false
 ---
-<section class="contibute-section container">
+<main class="contibute-section container">
     <div class="container">
         <h1>Getting Started with Cypht Community</h1>
         <h2>Introduction</h2>
@@ -66,4 +66,4 @@ h1: false
             and support newcomers. Feel free to reach out on <a href="https://gitter.im/cypht-org/community">Gitter.</a>
         </p>
     </div>
-</section>
+</main>

--- a/pages/index.md
+++ b/pages/index.md
@@ -4,6 +4,7 @@ weight: 1
 nocontainer: true
 h1: Welcome to Cypht
 ---
+<main>
 <section class="banner">
     <div class="container-fluid">
         <div class="row align-items-center">
@@ -123,3 +124,4 @@ h1: Welcome to Cypht
         </a>
     </div>
 </section>
+</main>

--- a/pages/index.md
+++ b/pages/index.md
@@ -2,6 +2,7 @@
 title: Home
 weight: 1
 nocontainer: true
+h1: Welcome to Cypht
 ---
 <section class="banner">
     <div class="container-fluid">
@@ -106,9 +107,9 @@ nocontainer: true
             volunteer effort, so we can't
             afford a bounty program. We can however promise that any security issue reported to us before release
             will receive a quick response, a thorough review, a sincere thanks, and an honorable mention on this
-            page. </p><a href="security.html">
-        <button type="button" class="btn btn-success">Read more</button>
-    </a>
+            page. </p>
+            <a class="btn btn-success" href="/security">
+            Read more</a>
     </div>
 </section>
 <section class="module-section">
@@ -118,8 +119,7 @@ nocontainer: true
             we call them, "module sets". There is only one required set, the "core" modules. The components of any
             module set can be added to, or even replaced, by site specific modules. All the functionality of Cypht
             is broken out into module sets, and each set is built from small pieces that are also easy to override.
-        </p><a href="/modules">
-        <button type="button" class="btn btn-light">Read more</button>
-    </a>
+        </p><a class="btn btn-light" href="/modules">Read more
+        </a>
     </div>
 </section>

--- a/pages/modules.md
+++ b/pages/modules.md
@@ -259,5 +259,4 @@ weight: 20
 <p> For more information, check out the "hello world" module set. It illustrates how modules work and has loads of
     comments that explain what is going on:<br/><br />
 </p>
-<a href="https://github.com/cypht-org/cypht/tree/master/modules/hello_world">https://github.com/cypht-org/cypht/tree/master/modules/hello_world</a>
-<br />
+https://github.com/cypht-org/cypht/tree/master/modules/hello_world

--- a/static/site.css
+++ b/static/site.css
@@ -1261,12 +1261,17 @@ h3 {
 	padding: 20px;
 }
 
-.content-section-doc h1{
+.content-section-doc h1, .content-section-doc h2 {
 	padding-left: 20px;
 	padding-right: 20px;
 	font-size: 2em;
 	font-weight: bold;
 	color: #80B444;
+	line-height: 48px;
+}
+
+.content-section-doc h2 {
+	margin-top: 1rem;
 }
 
 .content-section li {
@@ -1325,5 +1330,69 @@ html,body{
 	}
 }
 
+.line-between li {
+	padding-bottom: 1rem;
+	margin-bottom: 1rem;
+	border: 0;
+	border-bottom: 1px solid rgba(0, 0, 0, .1)
+}
+
+#config-generator {
+	width: 80%;
+	margin: auto;
+}
+
+#config-generator summary h2 {
+	display: inline;
+}
+
+fieldset#CYPHT_MODULES {
+	word-break: break-all;
+}
+
+#config-generator #generate,
+#config-generator #reset-all {
+	margin: auto;
+	display: block;
+	margin-bottom: 20px;
+}
+
+#config-generator #result {
+	height: 600px;
+}
+
+.dev-docs-section .highlight-text {
+	font-size: 18px;
+	color: #0e0d0d;
+}
+
+.dev-docs-section .highlight-secondary {
+	color: #635108;
+}
+
+.dev-docs-section .code-block {
+	display: block;
+	background-color: #1e1e1e;
+	color: #f8f8f2;
+	padding: 15px;
+	border-radius: 5px;
+	font-size: 16px;
+	line-height: 1;
+	overflow-x: auto;
+	white-space: pre-wrap;
+	margin-bottom: 20px;
+}
+
+.dev-docs-section .function-keyword {
+	color: #66d9ef;
+}
+
+.dev-docs-section .default-text {
+	color: #f8f8f2;
+}
+
+.dev-docs-section .bold-title {
+    font-weight: bold;
+}
 
 /*.navbar-toggler { position: absolute; left: 20px; top: 20px; }*/


### PR DESCRIPTION
# Changes
Finally, to help some stuff off #95. Below is the git commit message, but formatted & with w3 validator/outline results (first image original, second image from post-patch). Excuse the lack of alt text for the images, but it'd be a little bit too much manual work for a GitHub Issue


## CSS:
- Added .line-between, to no longer use `<hr>` aside `<li>` elements
- Added style for config-generator (see below)

## Layout:
- Added lang="en"
- Added footer element
- .social-section is now a nav
- Added aria-labels to nav elements
- Added `<h1>` and `<h2>` elements to improve the outline

## Index:
- Replaced `<a><button> ` with `<a class="btn">`
![image](https://github.com/user-attachments/assets/265a34d1-a75e-410a-994a-5d31b52b997e)
![image](https://github.com/user-attachments/assets/17601786-615a-44b4-ad05-c5e0821edabd)
---
![image](https://github.com/user-attachments/assets/98099fdf-913b-4b10-8669-34af37edc036)
![image](https://github.com/user-attachments/assets/2ddffa72-f853-478f-bad9-4437ad041dc0)

## Features:
- Applied line-between, removed `<hr>`
![image](https://github.com/user-attachments/assets/86af0003-53a4-450b-8198-af0cd815ca29)
![image](https://github.com/user-attachments/assets/21994583-8ab6-4a3a-8bf3-60b2ff39d6e0)
---
![image](https://github.com/user-attachments/assets/79b419dc-7427-4452-bd75-00b9898c0c2c)
![image](https://github.com/user-attachments/assets/a5921b16-c9d5-44be-8d38-669e4534cc7a)



## Modules:
- Fixed double `<a>` tag on the bottom due to Markdown expanding full URL's
![image](https://github.com/user-attachments/assets/5a00a11b-0f25-419c-8d0d-c375b97d99e4)
![image](https://github.com/user-attachments/assets/69441b2c-f8ad-4621-a087-020389ae193b)
---
![image](https://github.com/user-attachments/assets/ba451dd6-da3b-4d2a-83ab-71db445744a4)
![image](https://github.com/user-attachments/assets/e5e90a8b-a7a4-4b8d-95ee-406679744897)


## config-generator:
- Moved style to CSS
- main -> form#config-genreator
- Changed markup for source code link

**NOTE:** Unchecked checkboxes are issues that are due to a possible Cypht (the application) bug

![image](https://github.com/user-attachments/assets/3d7c85a5-1fc8-49c9-8bb1-5a0a826a8bbb)
![image](https://github.com/user-attachments/assets/aea0a91f-a614-43ba-9e74-65e8351afadd)
![image](https://github.com/user-attachments/assets/14866eb9-0df5-4229-9123-f6a79ac151ab)
![image](https://github.com/user-attachments/assets/8b161af5-71eb-41ec-8f0a-f2ac445df216)

---

![image](https://github.com/user-attachments/assets/35e13474-f1b7-423e-9a52-e62df80ec1c3)
![image](https://github.com/user-attachments/assets/e5ecf0cd-91e5-4bec-a099-9183f869e37c)
...
![image](https://github.com/user-attachments/assets/c202afc1-1b1e-43dd-9cae-954435b210df)
 

## documentation:
- Moved h1's down to h2
- Adapted the corresponding css code to include h2
![image](https://github.com/user-attachments/assets/81e5e056-a942-4523-8f3c-1180286cacd5)
![image](https://github.com/user-attachments/assets/49791cfe-d29f-4b90-a3cc-a3f7e9b840af)
---
![image](https://github.com/user-attachments/assets/82de98ca-5d7d-4b4c-bf5d-b14b10366f27)
![image](https://github.com/user-attachments/assets/ebaecb17-ed33-4e14-8fc3-bb3445d75634)


## Dev-docs:
- Moved style to css
![image](https://github.com/user-attachments/assets/7e929b6f-5b1c-444c-99c1-dfb10dca89df)
![image](https://github.com/user-attachments/assets/a32f9e39-4d9e-47b3-9650-e11f9a961fb3)
![image](https://github.com/user-attachments/assets/69908ba6-d471-44c9-8eb5-a535445a049c)
---

![image](https://github.com/user-attachments/assets/042c4a01-f335-4576-a302-ba4d19a46d20)
![image](https://github.com/user-attachments/assets/48217587-05a5-4837-af69-a2b7cb35bacb)


## Contribute:
- `<a><button> -> <a class="btn">`

![image](https://github.com/user-attachments/assets/f456c637-3eb9-493b-ae77-7bddba570879)
![image](https://github.com/user-attachments/assets/31f78f10-d95c-46d4-a14e-5bde6c939693)

---
![image](https://github.com/user-attachments/assets/546a8ac0-f36f-4b89-8302-6665f2131ee3)
![image](https://github.com/user-attachments/assets/08101c44-0851-4a21-8e04-1c6042342a60)



## email-filters:
- List now uses .line-between instead of `<hr>`
- Changed markup for related links
![image](https://github.com/user-attachments/assets/5bf0cf45-89c4-4fca-a2af-a389630ef7ff)
![image](https://github.com/user-attachments/assets/085ff1e1-156e-4635-bab9-91f2a2cc34c0)
---
![image](https://github.com/user-attachments/assets/c3d51c93-8724-4753-a294-6826de986526)
![image](https://github.com/user-attachments/assets/d10376be-94df-4260-9799-e25da978d417)


## how-to-join:
- Enabled noh1 for layout
![image](https://github.com/user-attachments/assets/0ace71f7-f8ac-4e79-998b-d60a42d3ce27)
![image](https://github.com/user-attachments/assets/0e6d0688-4afd-4399-b7ba-eeb41dd0d1e0)
---
![image](https://github.com/user-attachments/assets/d5b12768-613a-472f-9e8a-9fc56e466179)
![image](https://github.com/user-attachments/assets/2125e588-f2d7-4e7a-8f1a-a93283c853a1)


## License (not mentioned in git commit, as it is incidental to other changes)
![image](https://github.com/user-attachments/assets/1b68c925-05c2-4a00-b40e-4f77fb2b7ee8)
![image](https://github.com/user-attachments/assets/3e42da92-a658-4907-8e8c-e77fc29f0d4a)
---
![image](https://github.com/user-attachments/assets/69c0b58e-4344-48b2-b1fc-baf3d47b305d)
![image](https://github.com/user-attachments/assets/e2ea7ff5-4933-458f-9910-3c4640cbfafc)



## **Validation errors not fixed:**
- No clear headings in documentation.md: moving `<h2>` up breaks styling
- `<br />` is unneeded compared to `<br>`, but is kept for now
- Alt text is missing in devs-doc
- restore_aria_label in the example in dev-docs is kept, because I have no idea what's going on there
- install pages are not touched due to their recent/ongoing changes

