### PR TITLE
[MOD/FIX] Further HTML validating

### DIFF
--- a/pages/developers-documentation.md
+++ b/pages/developers-documentation.md
@@ -57,9 +57,12 @@ nocontainer: true
         <h2>Third-party integrations</h2>
         <p>Cypht is currently being actively used as embedded web mail client in Tiki. Be sure to read the integration code <a href="https://gitlab.com/tikiwiki/tiki/-/tree/master/lib/cypht?ref_type=heads">here</a> before doing changes in Cypht codebase, as some changes will require updates to the Tiki-Cypht integration and some changes might be done in a less disturbing way to prevent upstream from breaking. Be especially careful when doing bigger refactorings as module updates, overall layout updates, interface changes as in routing, error messaging, internal imap/smtp or other module updates. When in doubt, please request PR review from <a href="https://github.com/kroky">Victor</a>.</p>
         <h2>How to</h2>
+        <section id="new-link">
         <h3 class="bold-title"><b>See the new link in the left menu</b></h3>
         <p>Sometimes you can add a link to the left menu without seeing it. Cypht caches all menus. You need to
             click on the reload link below the navigation menu.</p>
+        </section>
+        <section id="create-a-page">
         <h3 class="bold-title"><b>Create a page</b></h3>
         <p>Cypht supports two types of pages: <b>basic</b> and <b>AJAX</b>. Basic pages are accessible via URL and require a page
             reload, while AJAX pages load asynchronously.</p>
@@ -171,7 +174,7 @@ nocontainer: true
         <p><b><b>Note:</b></b> A page can have multiple handlers/outputs. A full list of all handlers and outputs attached to
             a page can be seen by accessing <span class="function-keyword">?page=info</span> page on your instance in
             the <b>configuration map section</b>.</p>
-        <h3 class="bold-title"><b>Add third party</b></h3>
+        <h4 class="bold-title"><b>Add third party</b></h4>
         <p>Copy the minified file to the third-party directory</p>
        <p>
         Add the file path in <code>Hm_Output_page_js.output</code> or 
@@ -184,6 +187,8 @@ nocontainer: true
         <h3 class="bold-title"><b>Create a module</b></h3>
         <p>In the modules folder, you'll find a <b>hello_world</b> module with the necessary scaffolding for creating a
             new module. Customize your module by following the code explained above.</p>
+        </section>
+        <section id="translate-string">
         <h3 class="bold-title"><b>Translate string</b></h3>
         <p>If you need to translate a string in:</p>
         <p><span class="highlight-secondary">Handler module</span>:</p>
@@ -200,12 +205,12 @@ nocontainer: true
         </code>
         <p>The second parameter here is optional because the default language is the user's language in the settings
             page.</p>
-        <h3 class="bold-title"><b>Add new translation string</b></h3>
+        <h4 class="bold-title"><b>Add new translation string</b></h4>
         <p>Add your string to each file contained in the language folder.</p>
         <p>The file names in this folder are language codes. And all return an array. Just add your new string to
             the end of the array. If you know the translation of the text in a language, add it as a value,
             otherwise add false as a value.</p>
-        <h3 class="bold-title"><b>Add new language</b></h3>
+        <h4 class="bold-title"><b>Add new language</b></h4>
         <p>Duplicate the en.php file into the language folder</p>
         <p>Rename it (Cypht uses 2 digit code, please refer to <a
                 href="https://en.wikipedia.org/wiki/List_of_ISO_639_lingual_codes"
@@ -213,9 +218,11 @@ nocontainer: true
         <p>In the renamed file, modify interface_lang and interface_direction in the array accordingly.</p>
         <p>Add your language in the interface_langs() function.</p>
         <p>Update this test to add your language: Hm_Test_Core_Output_Modules::test_lingual_setting</p>
+        </section>
+        <section id="tests">
         <h3 class="bold-title"><b>Run test</b></h3>
         <p>Cypht has PHPUnit tests and selenium</p>
-        <h3 class="bold-title"><b> PHPUnit</b></h3>
+        <h4 class="bold-title"><b> PHPUnit</b></h4>
         <p>To run all tests:</p>
         <code style="display: block; background-color: #1e1e1e; color: #f8f8f2; padding: 15px; border-radius: 5px; font-size: 16px; line-height: 1.5; overflow-x: auto; white-space: pre-wrap; margin-bottom: 20px;">
             <span class="function-keyword"> php vendor/phpunit/phpunit/phpunit --configuration tests/phpunit/phpunit.xml</span>
@@ -239,7 +246,7 @@ nocontainer: true
         <code class="code-block">
             <span class="function-keyword">sh runall.sh</span>
         </code>
-        <h3 class="bold-title"><b>Fix PHPUnit failing tests</b></h3>
+        <h4 class="bold-title"><b>Fix PHPUnit failing tests</b></h4>
         <p>Run all tests or filter specific ones, and the console will show the results. In VSCode or similar, click
             on the file path to go directly to the line causing the issue. Check recent changes to classes, divs, or
             logic in the handlers that may be causing the failure.</p>
@@ -249,10 +256,14 @@ nocontainer: true
             <span class="default-text">Failed asserting that true is false.</span>
             <span class="default-text">/Applications/MAMP/htdocs/cypht/tests/phpunit/cache.php:19</span>
         </code>
+        </section>
+        <section id="debug-ajax-requests">
         <h3 class="bold-title"><b>Debug AJAX requests</b></h3>
         <p>Cypht relies heavily on AJAX requests. To debug, add var_dump and exit in your code. Open your browser's
             developer tools, go to the Network tab, filter by Fetch/XHR to see AJAX requests, then run the code.
             Click on the request you want to inspect and view the preview or response.</p>
+        </section>
+        <section id="the-core-module">
         <h3 class="bold-title"><b>The core module</b></h3>
         <p>The core module is responsible for:</p>
         <ul>
@@ -584,6 +595,8 @@ nocontainer: true
         <img src="/img/screenshots/7.png" style="width:100%; margin-bottom: 10px;"/>
         <p>Result after:</p>
         <img src="/img/screenshots/8.png" style="width:100%; margin-bottom: 10px;"/>
+        </section>
+        <section id="practical-example-2">
         <h3 class="bold-title"><b>Practical Example: 2. How to add new settings</b></h3>
         <p>Let's start by adding a simple parameter and then we'll see how to add another section after.</p>
         <p>We will add our setting after this content:</p>
@@ -792,6 +805,7 @@ nocontainer: true
         <p>And there you have it! Refresh your page to see the result:</p>
         <img src="/img/screenshots/12.png" style="width:100%; margin-bottom: 10px;"/>
     </div>
+    </section>
     <br/><br/>
     <h3>Related links:</h3>
     <a href="https://github.com/dovecot/imaptest/wiki/About">https://github.com/dovecot/imaptest/wiki/About</a><br>

--- a/pages/developers-documentation.md
+++ b/pages/developers-documentation.md
@@ -730,7 +730,7 @@ nocontainer: true
             <span class="default-text"> * Settings in this section control the tag messages view</span><br>
             <span class="function-keyword"> */</span><br>
             <span class="function-keyword">protected function output()</span> {<br>
-            <span class="default-text">    $res = '<tr><td data-target=".tag_setting" colspan="2" class="settings_subtitle cursor-pointer border-bottom p-2">'.</span><br>
+            <span class="default-text">    $res = '</span><tr><td data-target=".tag_setting" colspan="2" class="settings_subtitle cursor-pointer border-bottom p-2">'.<br>
             <span class="default-text">        '<i class="bi bi-tags fs-5 me-2"></i>'.</span><br>
             <span class="default-text">        $this->trans('Tags').'</td></tr>';</span><br>
             <span class="default-text">        print_r($res);</span><br>

--- a/pages/documentation.md
+++ b/pages/documentation.md
@@ -23,6 +23,7 @@ h1: false
 </section>
 
 <section class="content-section-doc container">
+    <h2 class="sr-only">After logging in</h2>
     <div class="line">
         <div class="element2 item">
             <p>After successfully logging in the webmail, the users will be redirected to the following home page of the webmail where the interactive interface allows user to perform multiple actions,</p>
@@ -35,6 +36,7 @@ h1: false
 
 
 <section class="content-section-doc container">
+    <h2 class="sr-only">Adding e-mail accounts</h2>
     <div class="line">
         <div class="element1 item">
             <img src="/img/Add.PNG" alt="add" class="img-fluid">
@@ -140,6 +142,7 @@ h1: false
 </section>
 
 <section class="content-section-doc container">
+    <h3 class="sr-only">One-click contact adding within a received message</h3>
     <div class="line">
         <div class="element2 item">
             <p class="text-center">Or simply by clicking on the “one-person” icon in the message you receive.</p>

--- a/pages/install.md
+++ b/pages/install.md
@@ -1,36 +1,38 @@
 ---
-title: Install
+title: Install Cypht
+h1: false
 exclude: true
 ---
-<section>
-    <h2>Install Cypht</h2>
-    <p>Cypht has four differents installation ways:</p>
-    <ul>
-        <li>Manual installation</li>
-        <li>Installation within Tiki</li>
-        <li>Install using Docker (use cypht docker image)</li>
-        <li>Install cypht on a YunoHost server</li>
-    </ul>
-    <hr>
+<h1>Install Cypht</h1>
+<p>Cypht has four differents installation ways:</p>
+<ul>
+    <li>Manual installation</li>
+    <li>Installation within Tiki</li>
+    <li>Install using Docker (use cypht docker image)</li>
+    <li>Install cypht on a YunoHost server</li>
+</ul>
+<hr>
 
-    <h2>1. Manual installation</h2>
-    <h2>Requirements</h2>
-    <p>
+<h2>1. Manual installation</h2>
+<h3>Requirements</h3>
+<p>
 
-            <a href="https://github.com/cypht-org/cypht/tree/1.4.x">Cypht 1.4.x</a> requires PHP 5.6 to 7.4. For PHP 8.1+, please use <a href="https://github.com/cypht-org/cypht/tree/2.x">Cypht 2.x+</a>, <a href="https://getcomposer.org/">Composer 2</a>, and at minimum the
-            <a href="http://php.net/manual/en/book.openssl.php">OpenSSL</a>, <a
-                href="http://php.net/manual/en/book.mbstring.php">mbstring</a> and <a
-                href="http://php.net/manual/en/book.curl.php">cURL</a> extensions. Cypht can also leverage several other
-            extensions as defined in <a                 href="https://github.com/cypht-org/cypht/blob/1.4.x/composer.json#L37-L44">composer.json</a>.
-            Testing is done on <a href="https://www.debian.org/">Debian</a> and <a
-                href="http://www.ubuntu.com/">Ubuntu</a>
-            platforms with <a href="http://nginx.com/">Nginx</a> and <a href="http://httpd.apache.org/">Apache</a>.
-    </p>
-    <p>Before proceeding please make sure your system meets minimal requirements</p>
-    <h2>Steps</h2>
-    <h4>1. Check minimum requirements</h4>
+    <a href="https://github.com/cypht-org/cypht/tree/1.4.x">Cypht 1.4.x</a> requires PHP 5.6 to 7.4. For PHP 8.1+,
+    please use <a href="https://github.com/cypht-org/cypht/tree/2.x">Cypht 2.x+</a>, <a
+        href="https://getcomposer.org/">Composer 2</a>, and at minimum the
+    <a href="http://php.net/manual/en/book.openssl.php">OpenSSL</a>, <a
+        href="http://php.net/manual/en/book.mbstring.php">mbstring</a> and <a
+        href="http://php.net/manual/en/book.curl.php">cURL</a> extensions. Cypht can also leverage several other
+    extensions as defined in <a
+        href="https://github.com/cypht-org/cypht/blob/1.4.x/composer.json#L37-L44">composer.json</a>.
+    Testing is done on <a href="https://www.debian.org/">Debian</a> and <a href="http://www.ubuntu.com/">Ubuntu</a>
+    platforms with <a href="http://nginx.com/">Nginx</a> and <a href="http://httpd.apache.org/">Apache</a>.
+</p>
+<p>Before proceeding please make sure your system meets minimal requirements</p>
+<h3>Steps</h3>
+<h4>1. Check minimum requirements</h4>
 
-    <pre>
+<pre>
         #!/bin/bash
         # You need to check php version. For Cypht version 1.4.x, ensure PHP version is between 5.6 and 7.4, while for version 2.x.x, PHP 8.1 or higher is required.
         php --version
@@ -282,9 +284,9 @@ exclude: true
                 install_cypht "$selected_version"
 
             </pre>
-        </div>
-        <div class="tab-pane fade" id="windows" role="tabpanel" aria-labelledby="windows-tab">
-            <pre>
+    </div>
+    <div class="tab-pane fade" id="windows" role="tabpanel" aria-labelledby="windows-tab">
+        <pre>
                 @echo off
                 setlocal enabledelayedexpansion
 
@@ -479,9 +481,9 @@ exclude: true
                 echo  %GREEN% ✓ Cypht %version%  installed successfully to %destination% %RESET%
                 pause
             </pre>
-        </div>
-        <div class="tab-pane fade" id="cpanel" role="tabpanel" aria-labelledby="cpanel-tab">
-            <pre>
+    </div>
+    <div class="tab-pane fade" id="cpanel" role="tabpanel" aria-labelledby="cpanel-tab">
+        <pre>
                 #!/bin/bash
 
                 bold_green() {
@@ -739,43 +741,53 @@ exclude: true
 
 
             </pre>
-        </div>
     </div>
+</div>
 
-    <h4>3. Configure the program</h4>
-    <p>
-        To configure Cypht for your environment, you must first edit the "hm3.ini" (for Cypht 1.4.x) or ".env"
-        (for Cypht 2.x.x) file to your liking, .env content can be generated using the <a href='/config-generator'>Cypht Config Generator</a>, then run the "config_gen.php" script to generate the optimized
-        configuration file and assets used at run-time.
-    </p>
+<h4>3. Configure the program</h4>
+<p>
+    To configure Cypht for your environment, you must first edit the "hm3.ini" (for Cypht 1.4.x) or ".env"
+    (for Cypht 2.x.x) file to your liking, .env content can be generated using the <a href='/config-generator'>Cypht
+        Config Generator</a>, then run the "config_gen.php" script to generate the optimized
+    configuration file and assets used at run-time.
+</p>
 
-    <p>
-        For Cypht 1.4.x, begin by editing the "hm3.ini" file to configure Cypht for your environment.
-        If you choose to use a database for any of the three available purposes (authentication, sessions, or user settings),
-        you will need to complete the "DB support" section and create the required tables.
-        SQL to do so can be found in the "hm3.sample.ini" file. The "hm3.ini" file contains many comments explaining each configuration option and how to set it up for your environment.
-    </p>
+<p>
+    For Cypht 1.4.x, begin by editing the "hm3.ini" file to configure Cypht for your environment.
+    If you choose to use a database for any of the three available purposes (authentication, sessions, or user
+    settings),
+    you will need to complete the "DB support" section and create the required tables.
+    SQL to do so can be found in the "hm3.sample.ini" file. The "hm3.ini" file contains many comments explaining each
+    configuration option and how to set it up for your environment.
+</p>
 
-    <pre>
+<pre>
         sudo mkdir -p /var/lib/hm3/{attachments,users,app_data}
         sudo chown -R www-data /var/lib/hm3/
     </pre>
 
-    <p>
-        The "/var/lib/hm3/users" directory is only required if you are using the file-system and not a database to store             user settings (user_config_type = file in the "hm3.ini" or ".env"). You can put these directories anywhere, just make sure the values in the ini file point to the right place.
-    </p>
-    <h4>4. Generate the run-time configuration</h4>
-    <p>Cypht uses a build process to create an optimized configuration, and to combine and minimize page assets.Once you have edited your "hm3.ini" or ".env" file, generate the configuration with:</p>
-    <pre>
+<p>
+    The "/var/lib/hm3/users" directory is only required if you are using the file-system and not a database to store
+    user settings (user_config_type = file in the "hm3.ini" or ".env"). You can put these directories anywhere, just
+    make sure the values in the ini file point to the right place.
+</p>
+<h4>4. Generate the run-time configuration</h4>
+<p>Cypht uses a build process to create an optimized configuration, and to combine and minimize page assets.Once you
+    have edited your "hm3.ini" or ".env" file, generate the configuration with:</p>
+<pre>
         cd /usr/local/share/cypht  (or wherever you put the code in section 1)
         sudo php ./scripts/config_gen.php
     </pre>
-    <p>Now going to https://your-server/mail/ should load the Cypht login page. Note that If you use a symlink, your web-server must be configured to follow symlinks.</p>
+<p>Now going to https://your-server/mail/ should load the Cypht login page. Note that If you use a symlink, your
+    web-server must be configured to follow symlinks.</p>
 
-    <h4>5. Enable the program in your web-server</h4>
-    <p>The easiest way to serve Cypht is to symlink it to the web-server document root. You can also copy the generated files to your web-server location, but then you will need to re-copy them anytime the config_gen script is run. If the source is located at /usr/local/share/cypht, and the web-server document root is at /var/www/html, the following command will make Cypht available under the "mail" path of the web-server:</p>
+<h4>5. Enable the program in your web-server</h4>
+<p>The easiest way to serve Cypht is to symlink it to the web-server document root. You can also copy the generated
+    files to your web-server location, but then you will need to re-copy them anytime the config_gen script is run. If
+    the source is located at /usr/local/share/cypht, and the web-server document root is at /var/www/html, the following
+    command will make Cypht available under the "mail" path of the web-server:</p>
 
-    <pre>
+<pre>
         sudo ln -s /usr/local/share/cypht/site /var/www/html/mail
     </pre>
 
@@ -823,10 +835,11 @@ exclude: true
 
     <p>Now going to https://your-server/mail/ should load the Cypht login page. Note that If you use a symlink, your web-server must be configured to follow symlinks.</p>
 
-    <h4>6. Users</h4>
-    <p>Setting up users depends on what type of authentication you configure in the hm3.ini file. If you are using the local database configuration for users, there are scripts in the scripts/ directory to help manage them:</p>
+<h4>6. Users</h4>
+<p>Setting up users depends on what type of authentication you configure in the hm3.ini file. If you are using the local
+    database configuration for users, there are scripts in the scripts/ directory to help manage them:</p>
 
-    <pre>
+<pre>
         # create an account
         php ./scripts/create_account.php username password
 
@@ -837,135 +850,152 @@ exclude: true
         php ./scripts/update_password.php username password
     </pre>
 
-    <h4>7. Debug mode</h4>
-    <p>Cypht has a debug or developer mode that can be used to troubleshoot problems or enable faster development of modules. To enable the debug version of Cypht, just sym-link the entire source directory instead of the site sub-directory:</p>
+<h4>7. Debug mode</h4>
+<p>Cypht has a debug or developer mode that can be used to troubleshoot problems or enable faster development of
+    modules. To enable the debug version of Cypht, just sym-link the entire source directory instead of the site
+    sub-directory:</p>
 
-    <pre>sudo ln -s /usr/local/share/cypht /var/www/html/mail-debug</pre>
-    <p>
-        Debug mode is not as efficient as the normal version, and it is NOT designed to be secure. DO NOT RUN DEBUG MODE IN PRODUCTION. You have been warned! Debug mode outputs lots of information to the PHP error log that can be useful for trouble-shooting problems. The location of the error log varies based on your php.ini settings and web-server software.
-    </p>
+<pre>sudo ln -s /usr/local/share/cypht /var/www/html/mail-debug</pre>
+<p>
+    Debug mode is not as efficient as the normal version, and it is NOT designed to be secure. DO NOT RUN DEBUG MODE IN
+    PRODUCTION. You have been warned! Debug mode outputs lots of information to the PHP error log that can be useful for
+    trouble-shooting problems. The location of the error log varies based on your php.ini settings and web-server
+    software.
+</p>
 
-    <h4>8. Other INI files</h4>
-    <p>
-        Some Cypht modules require additional ini files to be configured. These should NOT be inside the web-server document root. Cypht will look for them in the location defined by "app_data_dir" in the hm3.ini file. A sample ini file for each module set that requires one is included in the source for that module. To configure them you must copy the sample ini file to the "app_data_dir" and edit it for your setup. Some of these require configuring your service with a provider, specifically ones related to Oauth2 client setup (Github,  WordPress, Oauth2 over IMAP for Gmail and Outlook). Re-run the config_gen script after configuring an ini file and it will be merged into the main configuration settings.
-        <ul>
-            <li><b>Github</b>
-                <p>Cypht can connect to github and aggregate notification data about repository activity.<br />Example github.ini file:<br />
-                    <a
-                        href="https://github.com/cypht-org/cypht/blob/1.4.x/modules/github/github.ini">https://github.com/cypht-org/cypht/blob/1.4.x/modules/github/github.ini</a><br /><br />
-                    Authorize an application for github:<br />
-                    <a
-                        href="https://github.com/settings/developers">https://github.com/settings/developers</a>
-                </p>
-            </li>
-            <li><b>OAUTH2 over IMAP</b>
-                <p>Gmail and Outlook.com support OAUTH2 authentication over IMAP. This is preferable to normal IMAP
-                    authentication because Cypht never has access to your account password.<br /><br />
-                    Example oauth2 ini file:<br />
-                    <a
-                        href="https://github.com/cypht-org/cypht/blob/1.4.x/modules/imap/oauth2.ini">https://github.com/cypht-org/cypht/blob/1.4.x/modules/imap/oauth2.ini</a><br /><br />
-                    Authorize an application for gmail<br />
-                    <a
-                        href="https://console.developers.google.com/project">https://console.developers.google.com/project</a><br /><br />
-                    Authorize an application for outlook.com<br />
-                    <a
-                        href="https://account.live.com/developers/applications/">https://account.live.com/developers/applications/</a><br /><br />
-                </p>
-            </li>
-            <li><b>WordPress</b>
-                <p>Cypht can aggregate WordPress.com notifications.<br /><br />
-                    Example wordpress.ini file:<br />
-                    <a
-                        href="https://github.com/cypht-org/cypht/blob/1.4.x/modules/wordpress/wordpress.ini">https://github.com/cypht-org/cypht/blob/1.4.x/modules/wordpress/wordpress.ini</a><br /><br />
-                    Authorize an application for WordPress.com:<br />
-                    <a href="https://developer.wordpress.com/apps/">https://developer.wordpress.com/apps/</a>
-                </p>
-            </li>
-                        <li><b>Custom themes</b>
-                <p>
-                    You can create your own themes for Cypht. Edit the themes.ini file to include your theme, and put the css file in modules/themes/assets.<br />
-                    <a
-                        href="https://github.com/cypht-org/cypht/blob/1.4.x/modules/themes/themes.ini">https://github.com/cypht-org/cypht/blob/1.4.x/modules/themes/themes.ini</a>
-                </p>
-            </li>
-        </ul>
-    </p>
-
-    <h2>2. Install cypht using Docker</h2>
-    <p>
-        Using Docker is one of the easiest way to install cypht as the cypht docker image comes with all the steps required in the manual instalation done for you. But the bad news is that this installation way requiresdocker knowledge.<br /> Here is the cypht docker repository: <a                 href="https://hub.docker.com/r/sailfrog/cypht-docker">https://hub.docker.com/r/sailfrog/cypht-docker</a><br />
-        To run containers required by cypht, please, first make sure you have docker and docker-compose installed on
-        your system, then take a look on the section "example docker-compose" of repository overview, then do the
-        following:
-    </p>
-    <ul>
-        <li>Create a new directory on your system named as you want.</li>
-        <li>
-            In the directory created previously, create a file named "docker-compose.yaml" then copy and paste the content of <a href="https://hub.docker.com/r/sailfrog/cypht-docker">the example docker-compose section</a> in the created file.
-        </li>
-        <li>
-            Open your CLI/terminal and move to the directory containing the docker-compose file and run the command to run containers
-            <pre>docker-compose up -d</pre>
-        </li>
-        <li>
-            After containers started, you can access cypht on port 80 of your host if you didn't change the port value in the docker-compose file.
-        </li>
-    </ul>
-
+<h4>8. Other INI files</h4>
+<p>
+    Some Cypht modules require additional ini files to be configured. These should NOT be inside the web-server document
+    root. Cypht will look for them in the location defined by "app_data_dir" in the hm3.ini file. A sample ini file for
+    each module set that requires one is included in the source for that module. To configure them you must copy the
+    sample ini file to the "app_data_dir" and edit it for your setup. Some of these require configuring your service
+    with a provider, specifically ones related to Oauth2 client setup (Github, WordPress, Oauth2 over IMAP for Gmail and
+    Outlook). Re-run the config_gen script after configuring an ini file and it will be merged into the main
+    configuration settings.
+<ul>
+    <li><b>Github</b>
+        <p>Cypht can connect to github and aggregate notification data about repository activity.<br />Example
+            github.ini file:<br />
+            <a
+                href="https://github.com/cypht-org/cypht/blob/1.4.x/modules/github/github.ini">https://github.com/cypht-org/cypht/blob/1.4.x/modules/github/github.ini</a><br /><br />
+            Authorize an application for github:<br />
+            <a href="https://github.com/settings/developers">https://github.com/settings/developers</a>
+        </p>
+    </li>
+    <li><b>OAUTH2 over IMAP</b>
+        <p>Gmail and Outlook.com support OAUTH2 authentication over IMAP. This is preferable to normal IMAP
+            authentication because Cypht never has access to your account password.<br /><br />
+            Example oauth2 ini file:<br />
+            <a
+                href="https://github.com/cypht-org/cypht/blob/1.4.x/modules/imap/oauth2.ini">https://github.com/cypht-org/cypht/blob/1.4.x/modules/imap/oauth2.ini</a><br /><br />
+            Authorize an application for gmail<br />
+            <a
+                href="https://console.developers.google.com/project">https://console.developers.google.com/project</a><br /><br />
+            Authorize an application for outlook.com<br />
+            <a
+                href="https://account.live.com/developers/applications/">https://account.live.com/developers/applications/</a><br /><br />
+        </p>
+    </li>
+    <li><b>WordPress</b>
+        <p>Cypht can aggregate WordPress.com notifications.<br /><br />
+            Example wordpress.ini file:<br />
+            <a
+                href="https://github.com/cypht-org/cypht/blob/1.4.x/modules/wordpress/wordpress.ini">https://github.com/cypht-org/cypht/blob/1.4.x/modules/wordpress/wordpress.ini</a><br /><br />
+            Authorize an application for WordPress.com:<br />
+            <a href="https://developer.wordpress.com/apps/">https://developer.wordpress.com/apps/</a>
+        </p>
+    </li>
+    <li><b>Custom themes</b>
         <p>
-            NOTE: Please change usernames and passwords before using the given docker-compose code in your production
-            environment.
+            You can create your own themes for Cypht. Edit the themes.ini file to include your theme, and put the css
+            file in modules/themes/assets.<br />
+            <a
+                href="https://github.com/cypht-org/cypht/blob/1.4.x/modules/themes/themes.ini">https://github.com/cypht-org/cypht/blob/1.4.x/modules/themes/themes.ini</a>
         </p>
+    </li>
+</ul>
+</p>
 
-        <h2>3. Install Cypht on a YunoHost server</h2>
-        <p>This is an other easy way of installing and use Cypht.<br>
-            YunoHost is an operating system that aims to simplify server administration as much as possible to
-            democratize self-hosting while remaining reliable,
-            secure, ethical and lightweight. It is a free software project owned exclusively by volunteers. Technically,
-            it can be seen as a distribution based on
-            Debian GNU/Linux and can be installed on many types of hardware.<br />
-            To learn more about YunoHost, visit <a
-                href="https://yunohost.org/en/whatsyunohost">https://yunohost.org/en/whatsyunohost</a>
-        </p>
-        <p>To install Cypht on YunoHost, please follow these steps:</p>
-        <ul>
-            <li>
-                If you don't have an installed YunoHost server, please consult <a
-                    href="https://yunohost.org/#/install">the guide</a> to learn how to install it. If you have it,
-                please go directly to the next step.
-            </li>
-            <li>
-                If you just installed YunoHost or had it installed before, access your server and go to the admin
-                dashboard, then click on "Applications"
-            </li>
-            <li>In the next page, click on the "install" button</li>
-            <li>In the search area, enter "cypht"</li>
-            <li>In the search result, click on cypht app</li>
-            <li>
-                Scroll down, then fill in the form according to your need or keep the default values, then clik on the
-                "install" button. Note: Make sure the url value is not
-                used by another app on the server or in case you have another cypht instance previously installed you
-                have to modify it instead of using the default valuue.
-            </li>
-            <li>Once clicked on the "install" button, wait for the installation to complete, it may take while.</li>
-            <li>Once the installation completed, you will be taking back to the dashboard.</li>
-            <li>
-                To open the app, click on the app recently installed and then on the "open the app" button, then the
-                application opens in a new tab.
-            </li>
-            <li>
-                Enter the username and admin password you've provided previously in the installation form and then click
-                on the login button to enter cypht and start configuring your email accounts.
-            </li>
-        </ul>
+<h2>2. Install cypht using Docker</h2>
+<p>
+    Using Docker is one of the easiest way to install cypht as the cypht docker image comes with all the steps required
+    in the manual instalation done for you. But the bad news is that this installation way requiresdocker
+    knowledge.<br /> Here is the cypht docker repository: <a
+        href="https://hub.docker.com/r/sailfrog/cypht-docker">https://hub.docker.com/r/sailfrog/cypht-docker</a><br />
+    To run containers required by cypht, please, first make sure you have docker and docker-compose installed on
+    your system, then take a look on the section "example docker-compose" of repository overview, then do the
+    following:
+</p>
+<ul>
+    <li>Create a new directory on your system named as you want.</li>
+    <li>
+        In the directory created previously, create a file named "docker-compose.yaml" then copy and paste the content
+        of <a href="https://hub.docker.com/r/sailfrog/cypht-docker">the example docker-compose section</a> in the
+        created file.
+    </li>
+    <li>
+        Open your CLI/terminal and move to the directory containing the docker-compose file and run the command to run
+        containers
+        <pre>docker-compose up -d</pre>
+    </li>
+    <li>
+        After containers started, you can access cypht on port 80 of your host if you didn't change the port value in
+        the docker-compose file.
+    </li>
+</ul>
 
-                <h2>4. Install Cypht within Tiki</h2>
-        <p>If you have tiki installed, you can use Cypht within tiki. This is an easy way of installing Cypht.<br />
-            Please follow the following link for a complete guide of how to install and use cypht within Tiki.</br>
-            <a href="https://doc.tiki.org/Webmail">https://doc.tiki.org/Webmail</a>
-        </p></br>
-        <h4>Having problems?</h4>
-        We are happy to help trouble-shoot any installation issues you run into. Chat with us at Gitter <a href="https://gitter.im/cypht-org/community">Cypht at Gitter</a> and We'll get back to you as soon as we can.
+<p>
+    NOTE: Please change usernames and passwords before using the given docker-compose code in your production
+    environment.
+</p>
 
-</section>
+<h2>3. Install Cypht on a YunoHost server</h2>
+<p>This is an other easy way of installing and use Cypht.<br>
+    YunoHost is an operating system that aims to simplify server administration as much as possible to
+    democratize self-hosting while remaining reliable,
+    secure, ethical and lightweight. It is a free software project owned exclusively by volunteers. Technically,
+    it can be seen as a distribution based on
+    Debian GNU/Linux and can be installed on many types of hardware.<br />
+    To learn more about YunoHost, visit <a
+        href="https://yunohost.org/en/whatsyunohost">https://yunohost.org/en/whatsyunohost</a>
+</p>
+<p>To install Cypht on YunoHost, please follow these steps:</p>
+<ul>
+    <li>
+        If you don't have an installed YunoHost server, please consult <a href="https://yunohost.org/#/install">the
+            guide</a> to learn how to install it. If you have it,
+        please go directly to the next step.
+    </li>
+    <li>
+        If you just installed YunoHost or had it installed before, access your server and go to the admin
+        dashboard, then click on "Applications"
+    </li>
+    <li>In the next page, click on the "install" button</li>
+    <li>In the search area, enter "cypht"</li>
+    <li>In the search result, click on cypht app</li>
+    <li>
+        Scroll down, then fill in the form according to your need or keep the default values, then clik on the
+        "install" button. Note: Make sure the url value is not
+        used by another app on the server or in case you have another cypht instance previously installed you
+        have to modify it instead of using the default valuue.
+    </li>
+    <li>Once clicked on the "install" button, wait for the installation to complete, it may take while.</li>
+    <li>Once the installation completed, you will be taking back to the dashboard.</li>
+    <li>
+        To open the app, click on the app recently installed and then on the "open the app" button, then the
+        application opens in a new tab.
+    </li>
+    <li>
+        Enter the username and admin password you've provided previously in the installation form and then click
+        on the login button to enter cypht and start configuring your email accounts.
+    </li>
+</ul>
 
+<h2>4. Install Cypht within Tiki</h2>
+<p>If you have tiki installed, you can use Cypht within tiki. This is an easy way of installing Cypht.<br />
+    Please follow the following link for a complete guide of how to install and use cypht within Tiki.</br>
+    <a href="https://doc.tiki.org/Webmail">https://doc.tiki.org/Webmail</a>
+</p></br>
+<h4>Having problems?</h4>
+We are happy to help trouble-shoot any installation issues you run into. Chat with us at Gitter <a
+    href="https://gitter.im/cypht-org/community">Cypht at Gitter</a> and We'll get back to you as soon as we can.

--- a/static/site.css
+++ b/static/site.css
@@ -1217,8 +1217,8 @@ h3 {
 	font-weight: 700;
 }
 
-.footer-section p,
-h3 {
+.footer-section p, 
+.footer-section h3 {
 	color: #2F4858;
 	font-size: 20px;
 	font-weight: 300;


### PR DESCRIPTION
In progress PR to finish up #95

## Progress
- [x] Dev-docs: fix headers
- [ ] Dev-docs: valid HTML (blocked by needed feedback, see below)
- [x] Install: fix headers
- [x] install: valid HTML

## Needed feedback
### Dev-docs
- Does anyone know what the `restore_aria_label` usage is in devs-docs?
- There is a `<label for="tag_since">` without a matching input. I originally assumed it was just because it was a code example (as other code examples include `<label for="tag_per_source">`), but it doesn't show up on the page. Did some parsing go wrong there?

**Note:** After this PR, HTML validators might still error because of the lack of alt text on images. This is out of scope of this PR, as there is a general lack of alt text throughout the repo
